### PR TITLE
Corrected capitlisation of Tor

### DIFF
--- a/faq/misc/privacy.md
+++ b/faq/misc/privacy.md
@@ -30,5 +30,5 @@ sbot publish --type about --about "<YOURID>" --publicWebHosting
 Connecting to other peers to exchange gossip
 messages will reveal your IP and might be used to de-anonymize
 you. Luckily scuttlebutt has built in support for
-[Tor](https://torproject.org/). See the [tor page](tor.md) for more details.
+[Tor](https://torproject.org/). See the [SSB handbook page on Tor](tor.md) for more details.
 

--- a/faq/misc/privacy.md
+++ b/faq/misc/privacy.md
@@ -30,5 +30,5 @@ sbot publish --type about --about "<YOURID>" --publicWebHosting
 Connecting to other peers to exchange gossip
 messages will reveal your IP and might be used to de-anonymize
 you. Luckily scuttlebutt has built in support for
-[TOR](https://torproject.org/). See the [tor page](tor.md) for more details.
+[Tor](https://torproject.org/). See the [tor page](tor.md) for more details.
 

--- a/faq/misc/tor.md
+++ b/faq/misc/tor.md
@@ -11,10 +11,10 @@ You can find a list pubs available over Tor at the
 note that you might need to contact the person running it for an
 invite.
 
-Please note this is not an easy way to game the system or spam
-it. Scuttlebutt already has a great system for blocking users.
+Please note this is not an easy way to abuse or spam
+people. Scuttlebutt already has a great system for blocking users.
 
-Please note that even when using Tor the [normal
+Please note that even when using Tor, the [normal
 rules](https://www.whonix.org/wiki/DoNot) for staying anonymous still
 applies though.
 
@@ -31,8 +31,8 @@ HiddenServiceDir /var/lib/tor/hidden_service/
 HiddenServicePort 8008 127.0.0.1:8008
 ```
 
-And reload tor, then your onion address will be available in
-/var/lib/tor/hidden_service/hostname.
+And reload Tor, then your onion address will be available in
+`/var/lib/tor/hidden_service/hostname`.
 
 Besides hiding your IP and doing end-to-end encryption, Tor also does
 location transparency. Meaning your hostname will always stay the same
@@ -41,8 +41,8 @@ directly. No need to open ports in your firewall!
 
 This means that its possible to do p2p connections without pubs and
 talk direcly to your friends. If you create an invite from your
-machine (you probably need "allowPrivate": true in `/.ssb/config`),
+machine (you probably need to add `"allowPrivate": true` in `/.ssb/config`),
 replace the ip or hostname with your onion adress and send that to a
 friend. They will be able to connect directly to you and start
-receiving messages straight away, assuming your machine is running of
-course.
+receiving messages straight away, assuming your machine is online and running 
+of course.

--- a/faq/misc/tor.md
+++ b/faq/misc/tor.md
@@ -4,7 +4,7 @@ Scuttlebutt has built in support for
 [Tor](https://torproject.org/). You need to be running the TOR daemon
 for scuttlebutt to relay messages through the onion network. If you
 want secure scuttlebutt to ONLY connect to other Tor nodes, you need
-to pass a –tor-only flag when running sbot.
+to pass a `–tor-only` flag when running sbot.
 
 You can find a list pubs available over Tor at the
 [wiki](https://github.com/ssbc/scuttlebot/wiki/Pub-Servers). Please
@@ -24,10 +24,12 @@ Glad you asked.
 
 If you configure Tor as a hidden service and redirect port 8008 to
 localhost 8008 then your sbot service will be available over Tor. Add
-the following to /etc/tor/torrc:
+the following to `/etc/tor/torrc`:
 
+```
 HiddenServiceDir /var/lib/tor/hidden_service/
 HiddenServicePort 8008 127.0.0.1:8008
+```
 
 And reload tor, then your onion address will be available in
 /var/lib/tor/hidden_service/hostname.
@@ -39,7 +41,7 @@ directly. No need to open ports in your firewall!
 
 This means that its possible to do p2p connections without pubs and
 talk direcly to your friends. If you create an invite from your
-machine (you probably need "allowPrivate": true in ~/.ssb/config),
+machine (you probably need "allowPrivate": true in `/.ssb/config`),
 replace the ip or hostname with your onion adress and send that to a
 friend. They will be able to connect directly to you and start
 receiving messages straight away, assuming your machine is running of

--- a/faq/misc/tor.md
+++ b/faq/misc/tor.md
@@ -1,12 +1,12 @@
 # Can I use Scuttlebutt with Tor?
 
 Scuttlebutt has built in support for
-[TOR](https://torproject.org/). You need to be running the TOR daemon
+[Tor](https://torproject.org/). You need to be running the TOR daemon
 for scuttlebutt to relay messages through the onion network. If you
-want secure scuttlebutt to ONLY connect to other TOR nodes, you need
+want secure scuttlebutt to ONLY connect to other Tor nodes, you need
 to pass a –tor-only flag when running sbot.
 
-You can find a list pubs available over TOR at the
+You can find a list pubs available over Tor at the
 [wiki](https://github.com/ssbc/scuttlebot/wiki/Pub-Servers). Please
 note that you might need to contact the person running it for an
 invite.
@@ -14,16 +14,16 @@ invite.
 Please note this is not an easy way to game the system or spam
 it. Scuttlebutt already has a great system for blocking users.
 
-Please note that even when using TOR the [normal
+Please note that even when using Tor the [normal
 rules](https://www.whonix.org/wiki/DoNot) for staying anonymous still
 applies though.
 
-# What other cool things can I do with TOR?
+# What other cool things can I do with Tor?
 
 Glad you asked.
 
-If you configure TOR as a hidden service and redirect port 8008 to
-localhost 8008 then your sbot service will be available over TOR. Add
+If you configure Tor as a hidden service and redirect port 8008 to
+localhost 8008 then your sbot service will be available over Tor. Add
 the following to /etc/tor/torrc:
 
 HiddenServiceDir /var/lib/tor/hidden_service/
@@ -32,7 +32,7 @@ HiddenServicePort 8008 127.0.0.1:8008
 And reload tor, then your onion address will be available in
 /var/lib/tor/hidden_service/hostname.
 
-Besides hiding your IP and doing end-to-end encryption, TOR also does
+Besides hiding your IP and doing end-to-end encryption, Tor also does
 location transparency. Meaning your hostname will always stay the same
 no matter where you are connected, and anyone can connect to you
 directly. No need to open ports in your firewall!


### PR DESCRIPTION
The project is referred to as Tor not TOR. 

See: https://www.torproject.org/docs/faq.html.en#WhyCalledTor